### PR TITLE
OSC: Changes are now -std=gnu89 compatible

### DIFF
--- a/c/mpi/one-sided/osu_acc_latency.c
+++ b/c/mpi/one-sided/osu_acc_latency.c
@@ -46,6 +46,7 @@ int main (int argc, char *argv[])
     int nops = sizeof(op_list)/sizeof(op_list[0]);
     int ntypes = sizeof(dtype_list)/sizeof(dtype_list[0]);
     int type_name_size = 0;
+    int jtype_test, jop, jrank_print;
 
 
 #if MPI_VERSION >= 3
@@ -133,8 +134,8 @@ int main (int argc, char *argv[])
         nops = 1;
     }
 
-    for (int jtype_test=0; jtype_test<ntypes; jtype_test++) {
-    for (int jop = 0; jop < nops; jop++) {
+    for (jtype_test=0; jtype_test<ntypes; jtype_test++) {
+    for (jop = 0; jop < nops; jop++) {
         MPI_CHECK(MPI_Type_get_name(dtype_list[jtype_test], dtype_name_str, &type_name_size));
 
         if ( !is_mpi_op_allowed(dtype_list[jtype_test], op_list[jop]) ) {
@@ -175,7 +176,7 @@ int main (int argc, char *argv[])
     } }
 
     if (options.validate) {
-        for (int jrank_print=0; jrank_print<2; jrank_print++) {
+        for (jrank_print=0; jrank_print<2; jrank_print++) {
             if (jrank_print == rank) {
                 printf("-------------------------------------------\n");
                 printf("Atomic Data Validation results for Rank=%d:\n",rank);

--- a/c/mpi/one-sided/osu_cas_latency.c
+++ b/c/mpi/one-sided/osu_cas_latency.c
@@ -52,7 +52,7 @@ static const char* mpi_types_index_to_name(int type_index) {
 
 int main (int argc, char *argv[])
 {
-    int         rank,nprocs;
+    int         rank,nprocs,jtype_test,jrank_print;
     int         po_ret = PO_OKAY;
 
     MPI_Datatype dtype_list[] = {
@@ -138,7 +138,7 @@ int main (int argc, char *argv[])
         ntypes = 1;
     }
 
-    for (int jtype_test=0; jtype_test<ntypes; jtype_test++)
+    for (jtype_test=0; jtype_test<ntypes; jtype_test++)
     {
         char dtype_name_str[MPI_MAX_OBJECT_NAME];
         MPI_CHECK(MPI_Type_get_name(dtype_list[jtype_test], dtype_name_str, &type_name_size));
@@ -170,7 +170,7 @@ int main (int argc, char *argv[])
     }
 
     if (options.validate) {
-        for (int jrank_print=0; jrank_print<2; jrank_print++) {
+        for (jrank_print=0; jrank_print<2; jrank_print++) {
             if (jrank_print == rank) {
                 printf("-------------------------------------------\n");
                 printf("Atomic Data Validation results for Rank=%d:\n",rank);

--- a/c/mpi/one-sided/osu_fop_latency.c
+++ b/c/mpi/one-sided/osu_fop_latency.c
@@ -28,7 +28,7 @@ void run_fop_with_pscw(int rank, enum WINDOW win_type, MPI_Datatype data_type, M
 
 int main (int argc, char *argv[])
 {
-    int         rank,nprocs;
+    int         rank,nprocs,jdata_type,jop,jrank_print;
     int         po_ret = PO_OKAY;
 
     options.win = WIN_ALLOCATE;
@@ -132,8 +132,8 @@ int main (int argc, char *argv[])
         ntypes = 1;
         nops = 1;
     }
-    for (int jdata_type = 0; jdata_type < ntypes; jdata_type++) {
-    for (int jop = 0; jop < nops; jop++) {
+    for (jdata_type = 0; jdata_type < ntypes; jdata_type++) {
+    for (jop = 0; jop < nops; jop++) {
 
     MPI_Type_get_name(dtype_list[jdata_type], type_name, &type_name_size);
 
@@ -170,7 +170,7 @@ int main (int argc, char *argv[])
     }}
 
     if (options.validate) {
-        for (int jrank_print=0; jrank_print<2; jrank_print++) {
+        for (jrank_print=0; jrank_print<2; jrank_print++) {
             if (jrank_print == rank) {
                 printf("-------------------------------------------\n");
                 printf("Atomic Data Validation results for Rank=%d:\n",rank);

--- a/c/mpi/one-sided/osu_osc_verify.c
+++ b/c/mpi/one-sided/osu_osc_verify.c
@@ -487,13 +487,15 @@ static int validation_input_value(MPI_Datatype dtype, int jrank, void *val) {
 		*(double*)val = (1+jrank)*1.11;
 	else if (dtype == MPI_LONG_DOUBLE)
 		*(long double*)val = (1+jrank)*1.11L;
+#ifdef I
 	else if (dtype == MPI_C_FLOAT_COMPLEX)
-		*(float complex*)val = CMPLXF( (1+jrank)*1.11f, (1+jrank*-0.5f) );
+		*(float complex*)val = (1+jrank)*1.11f, (1+jrank*-0.5f)*I;
 	else if (dtype == MPI_C_DOUBLE_COMPLEX) {
-		*(double complex*)val = CMPLX( (1+jrank)*1.11, (1+jrank*-0.5) );
+		*(double complex*)val = (1+jrank)*1.11, (1+jrank*-0.5)*I;
 	}
 	else if (dtype == MPI_C_LONG_DOUBLE_COMPLEX)
-		*(long double complex*)val = CMPLXL( (1+jrank)*1.11L, (1+jrank*-0.5L) );
+		*(long double complex*)val = (1+jrank)*1.11L, (1+jrank*-0.5L)*I;
+#endif
 	else {
 		fprintf(stderr, "No initial value defined, cannot perform data validation "
 				"on atomic operations using %s\n",


### PR DESCRIPTION
Existing usage of pthread_barrier_t in osu_latency_mt.c means becoming c89-compliant is not easily done.

Signed-off-by: Luke Robison <lrbison@amazon.com>