### PR TITLE
c/util: Fix a memory leak in validate_data()

### DIFF
--- a/c/util/osu_util_mpi.c
+++ b/c/util/osu_util_mpi.c
@@ -1317,9 +1317,11 @@ uint8_t validate_data(void* r_buf, size_t size, int num_procs,
                 }
                 if (memcmp(temp_char_r_buf, expected_buffer, num_elements)) {
                     free(temp_r_buf);
+                    free(expected_buffer);
                     return 1;
                 }
                 free(temp_r_buf);
+                free(expected_buffer);
                 return 0;
             }
             break;


### PR DESCRIPTION
In validate_data(), expected_buffer is not freed
after being malloced, which causes a memory leak
and could make the benchmark crash due to out of
memory. This patch fixes this issue.