### PR TITLE
pt2pt cuda memory bugfixes

### DIFF
--- a/c/mpi/pt2pt/osu_mbw_mr.c
+++ b/c/mpi/pt2pt/osu_mbw_mr.c
@@ -388,8 +388,8 @@ double calc_bw(int rank, int size, int num_pairs, int window_size, char **s_buf,
     omb_ddt_size = omb_ddt_get_size(size);
     omb_ddt_transmit_size = omb_ddt_assign(&omb_ddt_datatype, MPI_CHAR, size);
     if (options.buf_num == SINGLE) {
-        set_buffer_pt2pt(s_buf[0], rank, options.accel, 'a', size);
-        set_buffer_pt2pt(r_buf[0], rank, options.accel, 'b', size);
+        set_buffer_pt2pt_mul(s_buf[0], rank, options.accel, 'a', size, num_pairs);
+        set_buffer_pt2pt_mul(r_buf[0], rank, options.accel, 'b', size, num_pairs);
     }
 
 #ifdef _ENABLE_CUDA_KERNEL_
@@ -408,8 +408,8 @@ double calc_bw(int rank, int size, int num_pairs, int window_size, char **s_buf,
         }
 
         for (i = 0; i < window_size; i++) {
-            set_buffer_pt2pt(s_buf[i], rank, options.accel, 'a', size);
-            set_buffer_pt2pt(r_buf[i], rank, options.accel, 'b', size);
+            set_buffer_pt2pt_mul(s_buf[i], rank, options.accel, 'a', size, num_pairs);
+            set_buffer_pt2pt_mul(r_buf[i], rank, options.accel, 'b', size, num_pairs);
         }
     }
 

--- a/c/mpi/pt2pt/osu_multi_lat.c
+++ b/c/mpi/pt2pt/osu_multi_lat.c
@@ -150,8 +150,8 @@ static int multi_latency(int rank, int pairs)
         }
 
         omb_ddt_transmit_size = omb_ddt_assign(&omb_ddt_datatype, MPI_CHAR, size);
-        set_buffer_pt2pt(s_buf, rank, options.accel, 'a', size);
-        set_buffer_pt2pt(r_buf, rank, options.accel, 'b', size);
+        set_buffer_pt2pt_mul(s_buf, rank, options.accel, 'a', size, pairs);
+        set_buffer_pt2pt_mul(r_buf, rank, options.accel, 'b', size, pairs);
 
         if (size > LARGE_MESSAGE_SIZE) {
             options.iterations = options.iterations_large;

--- a/c/util/osu_util.c
+++ b/c/util/osu_util.c
@@ -403,7 +403,7 @@ void set_benchmark_name (const char * name)
 void enable_accel_support (void)
 {
     accel_enabled = ((CUDA_ENABLED || OPENACC_ENABLED || ROCM_ENABLED) &&
-            !(options.subtype == LAT_MT || options.subtype == LAT_MP));
+                     !(options.subtype == LAT_MP));
 }
 
 int process_options (int argc, char *argv[])
@@ -454,7 +454,7 @@ int process_options (int argc, char *argv[])
             }
         } else{
             if (options.subtype == LAT_MT) {
-                optstring = "+:hvm:x:i:t:cu:G:D:";
+                optstring = "+:hvm:x:i:t:d:cu:G:D:";
             } else if (options.subtype == LAT_MP) {
                 optstring = "+:hvm:x:i:t:cu:G:D:P:";
             } else if (options.subtype == BW) {

--- a/c/util/osu_util_mpi.c
+++ b/c/util/osu_util_mpi.c
@@ -354,7 +354,7 @@ void print_help_message (int rank)
         fprintf(stdout, "                              Options: single, multiple\n");
     }
 
-    if (accel_enabled && (options.subtype != LAT_MT) && (options.subtype != LAT_MP)) {
+    if (accel_enabled && (options.subtype != LAT_MP)) {
         fprintf(stdout, "  -d, --accelerator  TYPE     use accelerator device buffers, which can be of TYPE `cuda', \n");
         fprintf(stdout, "                              `managed', `openacc', or `rocm' (uses standard host buffers if not specified)\n");
     }

--- a/c/util/osu_util_mpi.c
+++ b/c/util/osu_util_mpi.c
@@ -928,13 +928,15 @@ void omb_ddt_append_stats(size_t omb_ddt_transmit_size)
 void set_buffer_pt2pt (void * buffer, int rank, enum accel_type type, int data,
                        size_t size)
 {
+    set_buffer_pt2pt_mul(buffer, rank, type, data, size, 1);
+}
+
+void set_buffer_pt2pt_mul (void * buffer, int rank, enum accel_type type, int data,
+                           size_t size, int pairs)
+{
     char buf_type = 'H';
 
-    if (options.bench == MBW_MR) {
-        buf_type = (rank < options.pairs) ? options.src : options.dst;
-    } else {
-        buf_type = (rank == 0) ? options.src : options.dst;
-    }
+    buf_type = (rank < pairs) ? options.src : options.dst;
 
     switch (buf_type) {
         case 'H':

--- a/c/util/osu_util_mpi.h
+++ b/c/util/osu_util_mpi.h
@@ -86,6 +86,8 @@ void free_buffer (void * buffer, enum accel_type type);
 void set_buffer (void * buffer, enum accel_type type, int data, size_t size);
 void set_buffer_pt2pt (void * buffer, int rank, enum accel_type type, int data,
                        size_t size);
+void set_buffer_pt2pt_mul (void * buffer, int rank, enum accel_type type, int data,
+                           size_t size, int pairs);
 void set_buffer_validation(void* s_buf, void* r_buf, size_t size,
                            enum accel_type type, int iter);
 void set_buffer_float (float * buffer, int is_send_buf, size_t size, int iter,


### PR DESCRIPTION
This patch contain 2 fixes:
- osu_latency_mt does not support accelerator memory
- osu_multi_lat fails `cudaMemset` - the `set_buffer_pt2pt` does not account for multi-pair buffers.